### PR TITLE
Fix the forward bug under proxy mode.

### DIFF
--- a/app/api/claude/[org_id]/[conversation_id]/v1/chat/completions/route.ts
+++ b/app/api/claude/[org_id]/[conversation_id]/v1/chat/completions/route.ts
@@ -12,7 +12,8 @@ export async function POST(
 ) {
     const { messages, stream = false } = await request.json();
     const init: RequestInit = claude.openaiToClaudeRequest(messages, params.org_id, params.conversation_id);
-    const response = await fetch(new URL('/api/claude/append_message', request.url), init);
+    const url = new URL(request.url).protocol === 'https:' ? request.url.replace('https:', 'http:') : request.url;
+    const response = await fetch(new URL('/api/claude/append_message', url), init);
 
     if (!response.ok) {
         return new Response(response.body, { status: 400 })

--- a/app/api/claude/[org_id]/[conversation_id]/v1/chat/completions/route.ts
+++ b/app/api/claude/[org_id]/[conversation_id]/v1/chat/completions/route.ts
@@ -12,7 +12,9 @@ export async function POST(
 ) {
     const { messages, stream = false } = await request.json();
     const init: RequestInit = claude.openaiToClaudeRequest(messages, params.org_id, params.conversation_id);
+    console.log("A01:" + request.url);
     const url = new URL(request.url).protocol === 'https:' ? request.url.replace('https:', 'http:') : request.url;
+    console.log("A02" + url);
     const response = await fetch(new URL('/api/claude/append_message', url), init);
 
     if (!response.ok) {

--- a/app/api/claude/[org_id]/v1/chat/completions/route.ts
+++ b/app/api/claude/[org_id]/v1/chat/completions/route.ts
@@ -14,7 +14,9 @@ export async function POST(
     const { messages, stream = false } = await request.json();
     const conversation_uuid = await claude.autoGetConversationId(params.org_id, request.url);
     const init: RequestInit = claude.openaiToClaudeRequest(messages, params.org_id, conversation_uuid);
+    console.log("A01:" + request.url);
     const url = new URL(request.url).protocol === 'https:' ? request.url.replace('https:', 'http:') : request.url;
+    console.log("A02" + url);
     const response = await fetch(new URL('/api/claude/append_message', url), init);
 
     if (!response.ok) {

--- a/app/api/claude/[org_id]/v1/chat/completions/route.ts
+++ b/app/api/claude/[org_id]/v1/chat/completions/route.ts
@@ -14,7 +14,8 @@ export async function POST(
     const { messages, stream = false } = await request.json();
     const conversation_uuid = await claude.autoGetConversationId(params.org_id, request.url);
     const init: RequestInit = claude.openaiToClaudeRequest(messages, params.org_id, conversation_uuid);
-    const response = await fetch(new URL('/api/claude/append_message', request.url), init);
+    const url = new URL(request.url).protocol === 'https:' ? request.url.replace('https:', 'http:') : request.url;
+    const response = await fetch(new URL('/api/claude/append_message', url), init);
 
     if (!response.ok) {
         return new Response(response.body, { status: 400 })


### PR DESCRIPTION
在转发之前先检查protocol是否为https，如果是https则改写为http。

解决了在服务器端反向代理的情况下`ERR_SSL_WRONG_VERSION_NUMBER` 的问题
```
- error TypeError: fetch failed
    at Object.fetch (node:internal/deps/undici/undici:11576:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  cause: [Error: 98CBF5449C7F0000:error:0A00010B:SSL routines:ssl3_get_record:wrong version number:../deps/openssl/openssl/ssl/record/ssl3_record.c:354:
  ] {
    library: 'SSL routines',
    reason: 'wrong version number',
    code: 'ERR_SSL_WRONG_VERSION_NUMBER'
  }
}
```
