### PR TITLE
[Claude:Bug fix]ERR_SSL_WRONG_VERSION_NUMBER

### DIFF
--- a/app/api/claude/[org_id]/[conversation_id]/v1/chat/completions/route.ts
+++ b/app/api/claude/[org_id]/[conversation_id]/v1/chat/completions/route.ts
@@ -12,7 +12,9 @@ export async function POST(
 ) {
     const { messages, stream = false } = await request.json();
     const init: RequestInit = claude.openaiToClaudeRequest(messages, params.org_id, params.conversation_id);
-    const response = await fetch(new URL('/api/claude/append_message', request.url), init);
+    const url = new URL(request.url); 
+    url.protocol = url.host.includes('localhost') ? 'http:' : 'https:';
+    const response = await fetch(new URL('/api/claude/append_message', url), init);
 
     if (!response.ok) {
         return new Response(response.body, { status: 400 })

--- a/app/api/claude/[org_id]/v1/chat/completions/route.ts
+++ b/app/api/claude/[org_id]/v1/chat/completions/route.ts
@@ -14,7 +14,9 @@ export async function POST(
     const { messages, stream = false } = await request.json();
     const conversation_uuid = await claude.autoGetConversationId(params.org_id, request.url);
     const init: RequestInit = claude.openaiToClaudeRequest(messages, params.org_id, conversation_uuid);
-    const response = await fetch(new URL('/api/claude/append_message', request.url), init);
+    const url = new URL(request.url); 
+    url.protocol = url.host.includes('localhost') ? 'http:' : 'https:';
+    const response = await fetch(new URL('/api/claude/append_message', url), init);
 
     if (!response.ok) {
         return new Response(response.body, { status: 400 })


### PR DESCRIPTION
Fix the wrong version number ERROR under reverse proxy mode.

在docker模式下使用反向代理，在调用`/claude/****/v1/chat/completions` 接口时会出ERR_SSL_WRONG_VERSION_NUMBER错误。
原因是在docker+反代模式下把请求转发到了 `https:localhost:3000`，而localhost不支持https。

修复内容：转发前判断`request.url.host`，如果是`https:localhost:3000`则改写为`http:localhost:3000`

docker模式已测试通过，vercel部署已测试通过。
