### PR TITLE
<fix>: fix claude model

### DIFF
--- a/libs/claude/conversions.ts
+++ b/libs/claude/conversions.ts
@@ -90,7 +90,7 @@ export const openaiToClaudeRequest = (
             "completion": {
                 "prompt": prompt,
                 "timezone": "Asia/Shanghai",
-                "model": "claude-2"
+                "model": "claude-2.1"
             },
             "organization_uuid": org_id,
             "conversation_uuid": conversation_id,


### PR DESCRIPTION
[WebAPI] Upgrade Claude model to v2.1

The WebAPI now uses Claude model v2.1. Upgrading the model prevents the 
"Invalid model" error some users were seeing.

The old v2.0 model is now deprecated. All endpoints should update to use
the new v2.1 model for compatibility.

Bug fixes:
- Fixes "Invalid model" crashes some users encountered